### PR TITLE
Include config.h in various files before any other include statements

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -12,6 +12,10 @@
  * %End-Header%
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 /*
  This is a workaround to allow compilation, but the one line that uses
  this constant will never run because we open the fs read-only.

--- a/src/file_type.c
+++ b/src/file_type.c
@@ -17,6 +17,11 @@
  *                                                                         *
  *   C Implementation: file_type                                           *
  ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/hard_link_stack.c
+++ b/src/hard_link_stack.c
@@ -16,6 +16,10 @@
  *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
  ***************************************************************************/
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 //construct for global collect of hardlinks
 
 #include <stdio.h>

--- a/src/imap_search.c
+++ b/src/imap_search.c
@@ -19,6 +19,10 @@
  * C Implementation: imap_search                                           *
  ***************************************************************************/
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 //header  util.h
 
 #include "util.h"

--- a/src/inode.c
+++ b/src/inode.c
@@ -15,6 +15,11 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
  ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/lookup_local.c
+++ b/src/lookup_local.c
@@ -15,6 +15,11 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
  ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 //header  util.h
 
 #include <stdio.h>

--- a/src/magic_block_scan.c
+++ b/src/magic_block_scan.c
@@ -18,6 +18,11 @@
  *                                                                         *
  *   C Implementation: magic_block_scan                                    * 
  ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/util.c
+++ b/src/util.c
@@ -15,6 +15,11 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
  ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
This is an indirect way to fix a compilation failure with musl libc. Glibc includes sys/stat.h as part of stdlib.h[1], which eventually typedefs dev_t[2]. Musl libc doesn't seem to pull that in like glibc does. The header file ext2fs.h uses dev_t in some of its function signatures[3], but the inclusion of sys/types.h is guarded by the macro `#ifdef HAVE_SYS_TYPES_H`[4].

So every time ext4magic tries to include ext2fs.h while building with musl, it fails with:

```
In file included from hard_link_stack.h:23,
from hard_link_stack.c:25:
/usr/include/ext2fs/ext2fs.h:1402:39: error: unknown type name 'dev_t'; did you mean 'div_t'?
1402 | extern char *ext2fs_find_block_device(dev_t device);
|                                       ^~~~~
|                                       div_t
/usr/include/ext2fs/ext2fs.h:1822:62: error: unknown type name 'mode_t'
1822 | extern int ext2fs_open_file(const char *pathname, int flags, mode_t mode);
|                                                              ^~~~~~
make[2]: *** [Makefile:467: ext4magic-hard_link_stack.o] Error 1
```

Autoconf actually declares HAVE_SYS_TYPES_H during ext4magic build, we just need to include config.h in the relevant C files so that the macro propagates. The alternative would be to pass -DHAVE_SYS_TYPES_H to gcc but that solution seems more of a hack compared to including config.h as it's meant to be included.

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=include/stdlib.h;h=580da9be15adf0c1034986f62dd89aaaf6498c3f;hb=HEAD#l20
[2] https://sourceware.org/git/?p=glibc.git;a=blob;f=io/sys/stat.h;h=1fa6d6e62ecb2e4b4f0039d0154307a6c27e3fa9;hb=HEAD#l40
[3] https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/lib/ext2fs/ext2fs.h#n1402
[4] https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/lib/ext2fs/ext2fs.h#n68