### PR TITLE
Add existing unofficial patches to the repo history

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -64,6 +64,7 @@ struct extent_path {
         int             visit_num;
         int             flags;
         blk64_t         end_blk;
+        blk64_t         blk;
         void            *curr;
 };
 
@@ -79,6 +80,7 @@ struct ext2_extent_handle {
         int                     type;
         int                     level;
         int                     max_depth;
+        int                     max_paths;
         struct extent_path      *path;
 };
 
@@ -180,6 +182,7 @@ errcode_t local_ext2fs_extent_open(ext2_filsys fs, struct ext2_inode inode,
                 ((((__u64) handle->inode->i_size_high << 32) +
                   handle->inode->i_size + (fs->blocksize - 1))
                  >> EXT2_BLOCK_SIZE_BITS(fs->super));
+        handle->path[0].blk = 0;
         handle->path[0].visit_num = 1;
         handle->level = 0;
         handle->magic = EXT2_ET_MAGIC_EXTENT_HANDLE;

--- a/src/inode.c
+++ b/src/inode.c
@@ -404,14 +404,14 @@ void dump_inode(FILE *out, const char *prefix,
         fprintf(out,
                         "%sFile ACL: %d    Directory ACL: %d Translator: %d\n",
                         prefix,
-                        inode->i_file_acl, LINUX_S_ISDIR(inode->i_mode) ? inode->i_dir_acl : 0,
+                        inode->i_file_acl, LINUX_S_ISDIR(inode->i_mode) ? inode->i_size_high : 0,
                         inode->osd1.hurd1.h_i_translator);
         else
                 fprintf(out, "%sFile ACL: %llu    Directory ACL: %d\n",
                         prefix,
                         inode->i_file_acl | ((long long)
                                 (inode->osd2.linux2.l_i_file_acl_high) << 32),
-                        LINUX_S_ISDIR(inode->i_mode) ? inode->i_dir_acl : 0);
+                        LINUX_S_ISDIR(inode->i_mode) ? inode->i_size_high : 0);
         if (os == EXT2_OS_LINUX)
                 fprintf(out, "%sLinks: %d   Blockcount: %llu\n",
                         prefix, inode->i_links_count,

--- a/src/recover.c
+++ b/src/recover.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <utime.h>
+#include <sys/sysmacros.h>
 
 #ifndef O_LARGEFILE
 #define O_LARGEFILE 0


### PR DESCRIPTION
I have found [few attempts](https://github.com/search?q=ext4magic&type=repositories) to keep `ext4magic` code on the GitHub. But two of them are remarkable. 

First one is this repo which preserves the latest state of the code of the [official repo](https://sourceforge.net/p/ext4magic/) including the [latest non-released commit](https://sourceforge.net/p/ext4magic/code/ci/99a57963c71afa255f50635dd4f7d4ff0b0324aa/), but also it preserves a history of commits which is valuable. On the other hand [bumbledbees/ext4magic](https://github.com/bumbledbees/ext4magic) repo includes most of the [unofficial patches](https://github.com/bumbledbees/ext4magic#included-patches) made by community, excluding [my patch](https://gitlab.archlinux.org/archlinux/packaging/packages/ext4magic/-/issues/1#note_178069) which is attempt to correctly fix [Debian issue #854497](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=854497).

I also want to have a single repo which contains the full code of the official repo preserving history with all unofficial patches applied. And it seems to me th the most logical way is to add all existing patches to this repo and keep it as the most complete version of the `ext4magic` code on GitHub. This is why I have opened this PR to this repo. Adding @bumbledbees to the discussion.